### PR TITLE
Update link to SPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Google Student Training in Engineering Program
 
 This repo contains the projects you'll work on for the first half of STEP.
-This work is based on the [Google Software Product Sprint](https://github.com/google/step) program.
+This work is based on the [Google Software Product Sprint](https://g.co/softwareproductsprint) program.
 
 To get started:
 


### PR DESCRIPTION
Link to SPS code base is currently broken. Updating it to point to: g.co/softwareproductsprint