### PR TITLE
Fix hello-world blobstore FormHandlerServlet's getUploadedFileUrl

### DIFF
--- a/walkthroughs/week-3-libraries/blobstore/blobstore-walkthrough.md
+++ b/walkthroughs/week-3-libraries/blobstore/blobstore-walkthrough.md
@@ -168,7 +168,7 @@ request to the `/my-form-handler` URL. The `doPost()` function gets the value
 entered in the text area, and it then gets the URL for the uploaded image. The
 `getUploadedFileUrl()` function might seem intimidating, but most of that is
 checking for corner cases. The core of the logic for getting the image URL is
-in the last 3 lines of code.
+in calling imagesService to retrieve the image's URL.
 
 You can then use that URL to create an `<img>` element. In a real project, you'd
 probably do something like store the image URL in an `ArrayList` or in

--- a/walkthroughs/week-3-libraries/blobstore/examples/hello-world/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
+++ b/walkthroughs/week-3-libraries/blobstore/examples/hello-world/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
@@ -24,6 +24,8 @@ import com.google.appengine.api.images.ImagesServiceFactory;
 import com.google.appengine.api.images.ServingUrlOptions;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import javax.servlet.annotation.WebServlet;
@@ -86,6 +88,14 @@ public class FormHandlerServlet extends HttpServlet {
     // Use ImagesService to get a URL that points to the uploaded file.
     ImagesService imagesService = ImagesServiceFactory.getImagesService();
     ServingUrlOptions options = ServingUrlOptions.Builder.withBlobKey(blobKey);
-    return imagesService.getServingUrl(options);
+
+    // To support running in Google Cloud Shell with AppEngine's devserver, we must use the relative
+    // path to the image, rather than the path returned by imagesService which contains a host.
+    try {
+      URL url = new URL(imagesService.getServingUrl(options));
+      return new URLurl.getPath();
+    } catch (MalformedURLException e) {
+      return imagesService.getServingUrl(options);
+    }
   }
 }


### PR DESCRIPTION
The URL returned by AppEngine's ImageService when running via devserver
specifies 'losthost:8080' as the host. Browsers are unable to resolve
'localhost:8080' as the application is running in Google Cloud Shell.

To support running in Google Cloud Shell, we therefore use the relative
path for images.