### PR TITLE
Add instructions to set Java 8 as the default Java version.

### DIFF
--- a/walkthroughs/week-2-web-development/portfolio-walkthrough.md
+++ b/walkthroughs/week-2-web-development/portfolio-walkthrough.md
@@ -51,6 +51,34 @@ in the Google Cloud Shell editor.
 
 You'll learn more about these files in the following steps.
 
+## Java 8
+
+Before you continue, set your default Java version to Java 8 by running this
+command:
+
+```bash
+sudo update-java-alternatives -s java-1.8.0-openjdk-amd64 && export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre
+```
+
+You can ignore any error messages about not being able to find alternatives for
+various plugins. Your Java version setting will persist unless you restart your
+Cloud shell instance. To permanently switch to Java 8, add the command above to
+your `.bashrc` file.
+
+### Why Java 8?
+
+Google Cloud recently announced support for Java 11, but Java 11 is not
+backwards compatible with every library in these walkthroughs. To make sure
+everything will work as expected, please use Java 8.
+
+To make sure you're using the correct version of Java, run this command:
+
+```bash
+java -version
+```
+
+If this command prints a version like `1.8.0_xxx`, then you're good to go!
+
 ## Run a Development Server
 
 This project is a web application that contains HTML files. To make that HTML


### PR DESCRIPTION
The [official documentation](https://cloud.google.com/shell/docs/how-cloud-shell-works) confirms that you can ignore the warnings.

(It also still assumes Java 8 is the default, so I don't feel as guilty not upgrading to Java 11 yet.)

This is the low-lift fix for issue #11.