### PR TITLE
Inline hard-reload instructions in walkthru

### DIFF
--- a/walkthroughs/week-2-web-development/portfolio-walkthrough.md
+++ b/walkthroughs/week-2-web-development/portfolio-walkthrough.md
@@ -164,10 +164,12 @@ After your server is running again, click the
 select `Preview on port 8080` to see your changes. Get in the habit of rerunning
 your dev server to test your changes often!
 
-**Note:** If you don't see your changes after you refresh, your browser might be
-caching an old version. Follow the instructions
-[here](https://en.wikipedia.org/wiki/Wikipedia:Bypass_your_cache) to execute a
-cache-clearing refresh.
+**Warning:** If you don't see your changes after you refresh, your browser might
+be caching an old version. Perform a
+[cache-clearing refresh](https://en.wikipedia.org/wiki/Wikipedia:Bypass_your_cache)
+to force your browser to download the new files. In Chrome, open the Chrome Menu
+and click More Tools > Developer Tools. Then click and hold the browser Refresh
+button and select Empty Cache and Hard Reload from the drop-down menu.
 
 ## Example
 


### PR DESCRIPTION
- The wiki page the guide links to caused some confusion for our group,
  e.g. Ctrl + F5 on a chromebook takes a screenshot rather than hard
  reloading
- Although opening the Dev Tools is a bit more involved, doing Empty
  Cache and Hard Reload will also clear assets that are downloaded after
  page load (e.g. lazy loaded scripts) while just a Hard Reload will
  only re-download assets which are explicitly listed in the DOM
  - https://stackoverflow.com/a/14969509