### PR TITLE
Update google-cloud-language maven package

### DIFF
--- a/walkthroughs/week-4-libraries/sentiment-analysis/examples/sentiment-analyzer/pom.xml
+++ b/walkthroughs/week-4-libraries/sentiment-analysis/examples/sentiment-analyzer/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-language</artifactId>
-      <version>1.55.0</version>
+      <version>1.100.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Version 1.55.0 is out-of-date and doesn't read the GCP project field correctly when using [user application default credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login).

This can cause auth errors in Cloud Shell when running locally with `mvn package appengine:run` and trying to make requests to the Natural Language API.

Cloud Shell uses generic VMs with no permissions to access the user's GCP project, so you need to set the terminal up with auth for your project when using `run`. It works when using `deploy` because AppEngine environment by default is tied to a GCP project and set up with permissions for that project.

You may need to do one clean build to avoid build errors after picking up this change `mvn clean package appengine:run`.